### PR TITLE
Thermal model

### DIFF
--- a/opendc-compute/opendc-compute-service/src/main/java/org/opendc/compute/service/driver/telemetry/HostSystemStats.java
+++ b/opendc-compute/opendc-compute-service/src/main/java/org/opendc/compute/service/driver/telemetry/HostSystemStats.java
@@ -46,6 +46,7 @@ public record HostSystemStats(
         double powerDraw,
         double energyUsage,
         double thermalPower,
+        double temperatureC,
         int guestsTerminated,
         int guestsRunning,
         int guestsError,

--- a/opendc-compute/opendc-compute-service/src/main/java/org/opendc/compute/service/driver/telemetry/HostSystemStats.java
+++ b/opendc-compute/opendc-compute-service/src/main/java/org/opendc/compute/service/driver/telemetry/HostSystemStats.java
@@ -33,6 +33,7 @@ import java.time.Instant;
  * @param bootTime The time at which the server started.
  * @param powerDraw Instantaneous power draw of the system (in W).
  * @param energyUsage The cumulative energy usage of the system (in J).
+ * @param thermalPower The thermal power dissipated by the system (in W).
  * @param guestsTerminated The number of guests that are in a terminated state.
  * @param guestsRunning The number of guests that are in a running state.
  * @param guestsError The number of guests that are in an error state.
@@ -44,6 +45,7 @@ public record HostSystemStats(
         Instant bootTime,
         double powerDraw,
         double energyUsage,
+        double thermalPower,
         int guestsTerminated,
         int guestsRunning,
         int guestsError,

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/SimHost.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/SimHost.kt
@@ -235,6 +235,7 @@ public class SimHost(
             machine.psu.powerDraw,
             machine.psu.energyUsage,
             machine.psu.thermalPower,
+            machine.psu.temperature,
             terminated,
             running,
             error,
@@ -259,7 +260,7 @@ public class SimHost(
             hypervisor.cpuCapacity,
             hypervisor.cpuDemand,
             hypervisor.cpuUsage,
-            hypervisor.cpuUsage / localCpuLimit
+            hypervisor.cpuUsage / localCpuLimit,
         )
     }
 

--- a/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/SimHost.kt
+++ b/opendc-compute/opendc-compute-simulator/src/main/kotlin/org/opendc/compute/simulator/SimHost.kt
@@ -234,6 +234,7 @@ public class SimHost(
             localBootTime,
             machine.psu.powerDraw,
             machine.psu.energyUsage,
+            machine.psu.thermalPower,
             terminated,
             running,
             error,
@@ -258,7 +259,7 @@ public class SimHost(
             hypervisor.cpuCapacity,
             hypervisor.cpuDemand,
             hypervisor.cpuUsage,
-            hypervisor.cpuUsage / localCpuLimit,
+            hypervisor.cpuUsage / localCpuLimit
         )
     }
 

--- a/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/ComputeMetricReader.kt
+++ b/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/ComputeMetricReader.kt
@@ -247,6 +247,7 @@ public class ComputeMetricReader(
             _cpuLostTime = table.cpuLostTime
             _powerDraw = table.powerDraw
             _energyUsage = table.energyUsage
+            _thermalPower = table.thermalPower
             _carbonIntensity = table.carbonIntensity
             _carbonEmission = table.carbonEmission
             _uptime = table.uptime
@@ -327,6 +328,10 @@ public class ComputeMetricReader(
         private var _energyUsage = 0.0
         private var previousPowerTotal = 0.0
 
+        override val thermalPower: Double
+            get() = _thermalPower
+        private var _thermalPower = 0.0
+
         override val carbonIntensity: Double
             get() = _carbonIntensity
         private var _carbonIntensity = 0.0
@@ -373,6 +378,7 @@ public class ComputeMetricReader(
             _cpuLostTime = hostCpuStats.lostTime
             _powerDraw = hostSysStats.powerDraw
             _energyUsage = hostSysStats.energyUsage
+            _thermalPower = hostSysStats.thermalPower
             _carbonIntensity = carbonTrace.getCarbonIntensity(absoluteTimestamp)
 
             _carbonEmission = carbonIntensity * (energyUsage / 3600000.0) // convert energy usage from J to kWh

--- a/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/ComputeMetricReader.kt
+++ b/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/ComputeMetricReader.kt
@@ -248,6 +248,7 @@ public class ComputeMetricReader(
             _powerDraw = table.powerDraw
             _energyUsage = table.energyUsage
             _thermalPower = table.thermalPower
+            _temperature = table.temperature
             _carbonIntensity = table.carbonIntensity
             _carbonEmission = table.carbonEmission
             _uptime = table.uptime
@@ -332,6 +333,10 @@ public class ComputeMetricReader(
             get() = _thermalPower
         private var _thermalPower = 0.0
 
+        override val temperature: Double
+            get() = _temperature
+        private var _temperature = 0.0
+
         override val carbonIntensity: Double
             get() = _carbonIntensity
         private var _carbonIntensity = 0.0
@@ -379,6 +384,7 @@ public class ComputeMetricReader(
             _powerDraw = hostSysStats.powerDraw
             _energyUsage = hostSysStats.energyUsage
             _thermalPower = hostSysStats.thermalPower
+            _temperature = hostSysStats.temperatureC
             _carbonIntensity = carbonTrace.getCarbonIntensity(absoluteTimestamp)
 
             _carbonEmission = carbonIntensity * (energyUsage / 3600000.0) // convert energy usage from J to kWh
@@ -412,6 +418,8 @@ public class ComputeMetricReader(
 
             _powerDraw = 0.0
             _energyUsage = 0.0
+            _thermalPower = 0.0
+            _temperature = 0.0
             _carbonIntensity = 0.0
             _carbonEmission = 0.0
         }

--- a/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/export/parquet/ParquetHostDataWriter.kt
+++ b/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/export/parquet/ParquetHostDataWriter.kt
@@ -148,27 +148,31 @@ public class ParquetHostDataWriter(path: File, bufferSize: Int) :
             consumer.addDouble(data.energyUsage)
             consumer.endField("energy_usage", 18)
 
-            consumer.startField("carbon_intensity", 19)
+            consumer.startField("thermal_power", 19)
+            consumer.addDouble(data.thermalPower)
+            consumer.endField("thermal_power", 19)
+
+            consumer.startField("carbon_intensity", 20)
             consumer.addDouble(data.carbonIntensity)
-            consumer.endField("carbon_intensity", 19)
+            consumer.endField("carbon_intensity", 20)
 
-            consumer.startField("carbon_emission", 20)
+            consumer.startField("carbon_emission", 21)
             consumer.addDouble(data.carbonEmission)
-            consumer.endField("carbon_emission", 20)
+            consumer.endField("carbon_emission", 21)
 
-            consumer.startField("uptime", 21)
+            consumer.startField("uptime", 22)
             consumer.addLong(data.uptime)
-            consumer.endField("uptime", 21)
+            consumer.endField("uptime", 22)
 
-            consumer.startField("downtime", 22)
+            consumer.startField("downtime", 23)
             consumer.addLong(data.downtime)
-            consumer.endField("downtime", 22)
+            consumer.endField("downtime", 23)
 
             val bootTime = data.bootTime
             if (bootTime != null) {
-                consumer.startField("boot_time", 23)
+                consumer.startField("boot_time", 24)
                 consumer.addLong(bootTime.toEpochMilli())
-                consumer.endField("boot_time", 23)
+                consumer.endField("boot_time", 24)
             }
 
             consumer.endMessage()
@@ -241,6 +245,9 @@ public class ParquetHostDataWriter(path: File, bufferSize: Int) :
                     Types
                         .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
                         .named("energy_usage"),
+                    Types
+                        .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+                        .named("thermal_power"),
                     Types
                         .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
                         .named("carbon_intensity"),

--- a/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/export/parquet/ParquetHostDataWriter.kt
+++ b/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/export/parquet/ParquetHostDataWriter.kt
@@ -152,27 +152,31 @@ public class ParquetHostDataWriter(path: File, bufferSize: Int) :
             consumer.addDouble(data.thermalPower)
             consumer.endField("thermal_power", 19)
 
-            consumer.startField("carbon_intensity", 20)
+            consumer.startField("temperature_C", 20)
+            consumer.addDouble(data.temperature)
+            consumer.endField("temperature_C", 20)
+
+            consumer.startField("carbon_intensity", 21)
             consumer.addDouble(data.carbonIntensity)
-            consumer.endField("carbon_intensity", 20)
+            consumer.endField("carbon_intensity", 21)
 
-            consumer.startField("carbon_emission", 21)
+            consumer.startField("carbon_emission", 22)
             consumer.addDouble(data.carbonEmission)
-            consumer.endField("carbon_emission", 21)
+            consumer.endField("carbon_emission", 22)
 
-            consumer.startField("uptime", 22)
+            consumer.startField("uptime", 23)
             consumer.addLong(data.uptime)
-            consumer.endField("uptime", 22)
+            consumer.endField("uptime", 23)
 
-            consumer.startField("downtime", 23)
+            consumer.startField("downtime", 24)
             consumer.addLong(data.downtime)
-            consumer.endField("downtime", 23)
+            consumer.endField("downtime", 24)
 
             val bootTime = data.bootTime
             if (bootTime != null) {
-                consumer.startField("boot_time", 24)
+                consumer.startField("boot_time", 25)
                 consumer.addLong(bootTime.toEpochMilli())
-                consumer.endField("boot_time", 24)
+                consumer.endField("boot_time", 25)
             }
 
             consumer.endMessage()
@@ -248,6 +252,9 @@ public class ParquetHostDataWriter(path: File, bufferSize: Int) :
                     Types
                         .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
                         .named("thermal_power"),
+                    Types
+                        .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
+                        .named("temperature_C"),
                     Types
                         .required(PrimitiveType.PrimitiveTypeName.DOUBLE)
                         .named("carbon_intensity"),

--- a/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/table/HostTableReader.kt
+++ b/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/table/HostTableReader.kt
@@ -118,6 +118,11 @@ public interface HostTableReader {
     public val energyUsage: Double
 
     /**
+     * The thermal power of the host in W (i.e., the power that is dissipated as heat).
+     */
+    public val thermalPower: Double
+
+    /**
      * The current carbon intensity of the host in gCO2 / kW.
      */
     public val carbonIntensity: Double

--- a/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/table/HostTableReader.kt
+++ b/opendc-compute/opendc-compute-telemetry/src/main/kotlin/org/opendc/compute/telemetry/table/HostTableReader.kt
@@ -123,6 +123,11 @@ public interface HostTableReader {
     public val thermalPower: Double
 
     /**
+     * The current temperature of the host in degrees Celsius.
+     */
+    public val temperature: Double
+
+    /**
      * The current carbon intensity of the host in gCO2 / kW.
      */
     public val carbonIntensity: Double

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimBareMetalMachine.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimBareMetalMachine.java
@@ -61,7 +61,6 @@ public final class SimBareMetalMachine extends SimAbstractMachine {
     private final Memory memory;
     private final List<NetworkAdapter> net;
     private final List<StorageDevice> disk;
-
     /**
      * Construct a {@link SimBareMetalMachine} instance.
      *

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimPsu.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimPsu.java
@@ -46,11 +46,6 @@ public abstract class SimPsu extends SimPowerInlet {
     public abstract double getPowerDraw();
 
     /**
-     * Return the idle power of a cpu from the PSU's CPU power model
-     */
-    public abstract double getIdlePower();
-
-    /**
      * Return the thermal power of the machine (in W).
      */
     public abstract double getThermalPower();

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimPsu.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimPsu.java
@@ -46,6 +46,16 @@ public abstract class SimPsu extends SimPowerInlet {
     public abstract double getPowerDraw();
 
     /**
+     * Return the idle power of a cpu from the PSU's CPU power model
+     */
+    public abstract double getIdlePower();
+
+    /**
+     * Return the thermal power of the machine (in W).
+     */
+    public abstract double getThermalPower();
+
+    /**
      * Return the cumulated energy usage of the machine (in J) measured at the inlet of the powers supply.
      */
     public abstract double getEnergyUsage();

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimPsu.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimPsu.java
@@ -56,6 +56,12 @@ public abstract class SimPsu extends SimPowerInlet {
     public abstract double getThermalPower();
 
     /**
+     * Return the temperature of the Host in degrees Celsius based on a power equation.
+     */
+    public abstract double getTemperature();
+
+
+    /**
      * Return the cumulated energy usage of the machine (in J) measured at the inlet of the powers supply.
      */
     public abstract double getEnergyUsage();

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimPsuFactories.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimPsuFactories.java
@@ -82,14 +82,18 @@ public class SimPsuFactories {
         }
 
         @Override
-        public double getPowerDraw() {
-            return 0;
-        }
+        public double getPowerDraw() {return 0;}
+
+        @Override
+        public double getIdlePower() { return 0;}
 
         @Override
         public double getEnergyUsage() {
             return 0;
         }
+
+        @Override
+        public double getThermalPower() {return 0;}
 
         @Override
         InPort getCpuPower(int id, ProcessingUnit model) {
@@ -156,6 +160,23 @@ public class SimPsuFactories {
         @Override
         public double getPowerDraw() {
             return powerDraw;
+        }
+
+        public double getIdlePower(){
+            return model.computePower(0.0);
+        }
+
+        @Override
+        public double getThermalPower() {
+            double dynamicPower = powerDraw;
+
+            //TODO check with Dante with if there is a way to get idle power from scenario input
+            double idlePower = model.computePower(0.0);
+
+            //TODO Figure out a better way to calculate static power
+            double staticPower = 20 * 0.12; // current (A) * voltage (V) based on typical values from an intel i7
+
+            return dynamicPower + idlePower + staticPower;
         }
 
         @Override

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimPsuFactories.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimPsuFactories.java
@@ -83,9 +83,6 @@ public class SimPsuFactories {
         public double getPowerDraw() { return 0;}
 
         @Override
-        public double getIdlePower() { return 0;}
-
-        @Override
         public double getEnergyUsage() { return 0;}
 
         @Override
@@ -130,7 +127,7 @@ public class SimPsuFactories {
 
         private double powerDraw;
         private double energyUsage;
-        private double current; //FIXME implement current when PSU is fully implemented
+        private double leakageCurrent; //FIXME implement current when PSU is fully implemented
         private double voltage; //FIXME implement voltage when PSU is fully implemented
 
         private final InHandler handler = new InHandler() {
@@ -165,19 +162,15 @@ public class SimPsuFactories {
             return powerDraw;
         }
 
-        public double getIdlePower(){
-            return model.computePower(0.0);
-        }
-
         @Override
         public double getThermalPower() {
-            // defining current (A) and voltage (V) based on typical values from an intel i7
-            current = 20;
-            voltage = 0.12;
+            // defining leakage current (A) and voltage (V) based on typical values from an intel i7
+            leakageCurrent = 0.001; // not the same as total current for the CPU, based off the data sheet values for different input signals summed together
+            voltage = 1.2;
 
             double dynamicPower = powerDraw;
             double idlePower = model.computePower(0.0);
-            double staticPower = current * voltage;
+            double staticPower = leakageCurrent * voltage;
 
             return dynamicPower + idlePower + staticPower;
         }

--- a/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimPsuFactories.java
+++ b/opendc-simulator/opendc-simulator-compute/src/main/java/org/opendc/simulator/compute/SimPsuFactories.java
@@ -77,23 +77,24 @@ public class SimPsuFactories {
         }
 
         @Override
-        public double getPowerDemand() {
-            return 0;
-        }
+        public double getPowerDemand() { return 0;}
 
         @Override
-        public double getPowerDraw() {return 0;}
+        public double getPowerDraw() { return 0;}
 
         @Override
         public double getIdlePower() { return 0;}
 
         @Override
-        public double getEnergyUsage() {
-            return 0;
-        }
+        public double getEnergyUsage() { return 0;}
 
         @Override
         public double getThermalPower() {return 0;}
+
+        @Override
+        public double getTemperature() {
+            return 0;
+        }
 
         @Override
         InPort getCpuPower(int id, ProcessingUnit model) {
@@ -129,6 +130,8 @@ public class SimPsuFactories {
 
         private double powerDraw;
         private double energyUsage;
+        private double current; //FIXME implement current when PSU is fully implemented
+        private double voltage; //FIXME implement voltage when PSU is fully implemented
 
         private final InHandler handler = new InHandler() {
             @Override
@@ -168,15 +171,25 @@ public class SimPsuFactories {
 
         @Override
         public double getThermalPower() {
+            // defining current (A) and voltage (V) based on typical values from an intel i7
+            current = 20;
+            voltage = 0.12;
+
             double dynamicPower = powerDraw;
-
-            //TODO check with Dante with if there is a way to get idle power from scenario input
             double idlePower = model.computePower(0.0);
-
-            //TODO Figure out a better way to calculate static power
-            double staticPower = 20 * 0.12; // current (A) * voltage (V) based on typical values from an intel i7
+            double staticPower = current * voltage;
 
             return dynamicPower + idlePower + staticPower;
+        }
+
+        @Override
+        public double getTemperature() {
+            // defining the temperature based on a linear equation with power draw for an Intel i7
+            double yIntercept = 43.2;
+            double slope = 0.19;
+            double dynamicPower = powerDraw;
+
+            return yIntercept + slope * dynamicPower;
         }
 
         @Override

--- a/opendc-simulator/opendc-simulator-compute/src/test/kotlin/org/opendc/simulator/compute/ThermalTest.kt
+++ b/opendc-simulator/opendc-simulator-compute/src/test/kotlin/org/opendc/simulator/compute/ThermalTest.kt
@@ -1,24 +1,81 @@
 package org.opendc.simulator.compute
 
+import kotlinx.coroutines.coroutineScope
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.yield
+import org.junit.jupiter.api.Assertions.assertAll
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.BeforeEach
+import org.opendc.simulator.compute.model.MachineModel
+import org.opendc.simulator.compute.model.MemoryUnit
+import org.opendc.simulator.compute.model.NetworkAdapter
+import org.opendc.simulator.compute.model.ProcessingNode
+import org.opendc.simulator.compute.model.ProcessingUnit
+import org.opendc.simulator.compute.model.StorageDevice
 import org.opendc.simulator.compute.power.CpuPowerModels
+import org.opendc.simulator.compute.workload.SimWorkloads
+import org.opendc.simulator.flow2.FlowEngine
+import org.opendc.simulator.power.SimPowerSource
+import org.opendc.simulator.kotlin.runSimulation
 
 class ThermalTest {
     private val maxPower = 130.0
     private val idlePower = 12.0
-    private val staticPower = 0.001 * 1.2
 
     private val powerModel = CpuPowerModels.linear(maxPower, idlePower)
+    private lateinit var machineModel: MachineModel
 
-    @Test
-    fun testThermalPower() {
-        val utilizationVals = listOf(0.25, 0.50, 0.75, 1.0) // Define the range of utilization values
-        val expectedThermalPower = listOf(53.5012, 83.0012, 112.5012, 142.0012) // Expected thermal power dissipation for each utilization
+    @BeforeEach
+    fun setUp() {
+        val cpuNode = ProcessingNode("Intel", "i7-900", "amd64", 8)
 
-        utilizationVals.forEachIndexed { i, u ->
-            assertEquals(expectedThermalPower[i], (idlePower + staticPower + powerModel.computePower(u)))
+        machineModel =
+            MachineModel(
+                List(cpuNode.coreCount) { ProcessingUnit(cpuNode, it, 3500.0) },
+                List(4) { MemoryUnit("Crucial", "MTA18ASF4G72AZ-3G2B1", 3200.0, 32_000) },
+                listOf(NetworkAdapter("Mellanox", "ConnectX-5", 25000.0)),
+                listOf(StorageDevice("Samsung", "EVO", 1000.0, 250.0, 250.0)),
+            )
+    }
+
+    private fun testUtilization(utilization: Double, expectedPower: Double, expectedTemperature: Double) =
+        runSimulation {
+            val engine = FlowEngine.create(dispatcher)
+            val graph = engine.newGraph()
+            val machine =
+                SimBareMetalMachine.create(
+                    graph,
+                    machineModel,
+                    SimPsuFactories.simple(powerModel),
+                )
+            val source = SimPowerSource(graph, 1000.0f)
+            source.connect(machine.psu)
+
+            coroutineScope {
+                launch { machine.runWorkload(SimWorkloads.flops(2_000, utilization)) }
+
+                yield()
+                assertAll( {
+                    assertEquals(expectedPower, machine.psu.thermalPower, 0.0001, "The power draw should be $expectedPower W")
+                    assertEquals(expectedTemperature, machine.psu.temperature, 0.0001, "The temperature should be $expectedTemperature C")
+                })
+            }
         }
 
-    }
+    @Test
+    fun zeroUtilization() = testUtilization(0.0, 24.0012, 45.48)
+
+    @Test
+    fun quarterUtilization() = testUtilization(0.25, 53.5012, 51.085)
+
+    @Test
+    fun halfUtilization() = testUtilization(0.50, 83.0012, 56.69)
+
+    @Test
+    fun threeQuarterUtilization() = testUtilization(0.75, 112.5012, 62.295)
+
+    @Test
+    fun fullUtilization() = testUtilization(1.0, 142.0012, 67.9)
+
 }

--- a/opendc-simulator/opendc-simulator-compute/src/test/kotlin/org/opendc/simulator/compute/ThermalTest.kt
+++ b/opendc-simulator/opendc-simulator-compute/src/test/kotlin/org/opendc/simulator/compute/ThermalTest.kt
@@ -1,0 +1,24 @@
+package org.opendc.simulator.compute
+
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.opendc.simulator.compute.power.CpuPowerModels
+
+class ThermalTest {
+    private val maxPower = 130.0
+    private val idlePower = 12.0
+    private val staticPower = 0.001 * 1.2
+
+    private val powerModel = CpuPowerModels.linear(maxPower, idlePower)
+
+    @Test
+    fun testThermalPower() {
+        val utilizationVals = listOf(0.25, 0.50, 0.75, 1.0) // Define the range of utilization values
+        val expectedThermalPower = listOf(53.5012, 83.0012, 112.5012, 142.0012) // Expected thermal power dissipation for each utilization
+
+        utilizationVals.forEachIndexed { i, u ->
+            assertEquals(expectedThermalPower[i], (idlePower + staticPower + powerModel.computePower(u)))
+        }
+
+    }
+}


### PR DESCRIPTION
## Summary

* Added a thermal power model based off dynamic, idle, and static power.
* Added a model to get temperature in celsius based on dynamic power draw.

## Implementation Notes :hammer_and_pick:

* The thermal power model uses the law of conservation of energy to state that all the power (ie electrical energy) consumed by a processor is converted to heat energy therefore once all three components of power consumption have been calculated, thermal power draw can be calculated.
* The temperature model is based off Intel's i7 physical measurements and uses a linear model to predict temperature values in degrees Celsius.

## External Dependencies :four_leaf_clover:

* N/A

## Breaking API Changes :warning:

* N/A

*Simply specify none (N/A) if not applicable.*